### PR TITLE
Kerr Lamp Post

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,12 @@
+name = "AccretionDiscProfiles"
+uuid = "cabb4e56-f255-44e8-a431-a93e8eef5d9b"
+authors = ["fjebaker <fergusbkr@gmail.com>"]
+version = "0.1.0"
+
+[deps]
+AccretionGeometry = "7f85384a-175b-40eb-971c-1f0b02ab1b9a"
+ComputedGeodesicEquations = "42910a5e-bdf1-4870-a538-dfa35571a56d"
+GeodesicBase = "1f539516-e6d2-4f24-ab09-50f3ac3c4a5a"
+GeodesicTracer = "1f548346-32cf-4117-8ecc-304cf7418187"
+Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AccretionDiscProfiles"
 uuid = "cabb4e56-f255-44e8-a431-a93e8eef5d9b"
 authors = ["fjebaker <fergusbkr@gmail.com>"]
-version = "0.1.0"
+version = "0.0.1"
 
 [deps]
 AccretionGeometry = "7f85384a-175b-40eb-971c-1f0b02ab1b9a"

--- a/src/AccretionDiscProfiles.jl
+++ b/src/AccretionDiscProfiles.jl
@@ -1,0 +1,50 @@
+module AccretionDiscProfiles
+
+using Parameters
+
+import StaticArrays: @SVector
+
+# this should be an optional dependency
+# as should CarterBoyerLindquist
+using ComputedGeodesicEquations
+
+import GeodesicBase: AbstractMetricParams
+import GeodesicTracer: tracegeodesics
+import AccretionGeometry
+
+
+abstract type AbstractCoronaModel{T} end
+
+sample_position(m::AbstractMetricParams{T}, model::AbstractCoronaModel{T}, N) where {T} = error("Not implemented for $(typeof(model)).")
+sample_random_direction(m::AbstractMetricParams{T}, model::AbstractCoronaModel{T}, us, N) where {T} = error("Not implemented for $(typeof(model)).") 
+sample_even_direction(m::AbstractMetricParams{T}, model::AbstractCoronaModel{T}, us, N) where {T} = error("Not implemented for $(typeof(model)).") 
+
+function tracegeodesics(
+    m::AbstractMetricParams{T},
+    model::AbstractCoronaModel{T},
+    time_domain::Tuple{T,T};
+    n_samples=1024,
+    kwargs...
+) where {T}
+    us = sample_position(m, model, n_samples)
+    vs = sample_random_direction(m, model, n_samples, us)
+    tracegeodesics(m, us, vs, time_domain; kwargs...)
+end
+
+function renderprofile(
+    m::AbstractMetricParams{T},
+    model::AbstractCoronaModel{T},
+    max_time::T;
+    N=2048,
+    kwargs...
+)
+
+end
+
+include("sky-geometry.jl")
+include("corona-models.jl")
+
+export AbstractCoronaModel, tracegeodesics, renderprofile
+
+
+end # module

--- a/src/AccretionDiscProfiles.jl
+++ b/src/AccretionDiscProfiles.jl
@@ -10,41 +10,89 @@ using ComputedGeodesicEquations
 
 import GeodesicBase: AbstractMetricParams
 import GeodesicTracer: tracegeodesics
-import AccretionGeometry
+import AccretionGeometry: AbstractAccretionGeometry, tracegeodesics
 
 
 abstract type AbstractCoronaModel{T} end
 
 sample_position(m::AbstractMetricParams{T}, model::AbstractCoronaModel{T}, N) where {T} = error("Not implemented for $(typeof(model)).")
-sample_random_direction(m::AbstractMetricParams{T}, model::AbstractCoronaModel{T}, us, N) where {T} = error("Not implemented for $(typeof(model)).") 
-sample_even_direction(m::AbstractMetricParams{T}, model::AbstractCoronaModel{T}, us, N) where {T} = error("Not implemented for $(typeof(model)).") 
+
+function sample_random_direction(m::AbstractMetricParams{T}, model::AbstractCoronaModel{T}, us, N) where {T}
+    map(1:N) do index
+        ϕ = rand(T) * 2π
+        θ = acos(1 - 2*rand(T))
+        r, t, p = vector_to_local_sky(m, us[index], θ, ϕ)
+        @SVector [T(0.0), r, t, p]
+    end
+end
+
+function sample_even_direction(m::AbstractMetricParams{T}, model::AbstractCoronaModel{T}, us, N) where {T}
+    map(1:N) do index
+        θ = acos(1 - 2 * (index / N))
+        # golden ratio
+        ϕ = π * (1 + √5) * index
+        r, t, p = vector_to_local_sky(m, us[index], θ, ϕ)
+        @SVector [T(0.0), r, t, p]
+    end
+end
+
+@inline function sample_velocity(m::AbstractMetricParams{T}, model::AbstractCoronaModel{T}, us, N; sampler) where {T}
+    if sampler == :random
+        sample_random_direction(m, model, us, N)
+    elseif sampler == :even
+        sample_even_direction(m, model, us, N)
+    else
+        error("Unknown sampling method $(sampler)")
+    end
+end
 
 function tracegeodesics(
     m::AbstractMetricParams{T},
     model::AbstractCoronaModel{T},
     time_domain::Tuple{T,T};
     n_samples=1024,
+    sampler=:even,
     kwargs...
 ) where {T}
     us = sample_position(m, model, n_samples)
-    vs = sample_random_direction(m, model, n_samples, us)
+    vs = sample_velocity(m, model, us, n_samples; sampler=sampler)
     tracegeodesics(m, us, vs, time_domain; kwargs...)
 end
+
+
+function tracegeodesics(
+    m::AbstractMetricParams{T},
+    model::AbstractCoronaModel{T},
+    time_domain::Tuple{T,T},
+    d::AbstractAccretionGeometry{T},
+    ;
+    n_samples=1024,
+    sampler=:even,
+    kwargs...
+) where {T}
+    us = sample_position(m, model, n_samples)
+    vs = sample_velocity(m, model, us, n_samples; sampler=sampler)
+    tracegeodesics(m, us, vs, time_domain, d; kwargs...)
+end
+
 
 function renderprofile(
     m::AbstractMetricParams{T},
     model::AbstractCoronaModel{T},
-    max_time::T;
-    N=2048,
+    max_time::T,
+    d::AbstractAccretionGeometry{T}
+    ;
+    n_samples=2048,
+    sampler=:even,
     kwargs...
-)
-
+) where {T}
+    __renderprofile(m, model, d, n_samples, (0.0, max_time); kwargs...)
 end
+
 
 include("sky-geometry.jl")
 include("corona-models.jl")
 
 export AbstractCoronaModel, tracegeodesics, renderprofile
-
 
 end # module

--- a/src/corona-models.jl
+++ b/src/corona-models.jl
@@ -1,0 +1,23 @@
+
+@with_kw struct LampPostModel{T} <: AbstractCoronaModel{T}
+    @deftype T
+    h = 5.0
+    θ = 0.01
+    ϕ = 0.0
+end
+
+function sample_position(::AbstractMetricParams{T}, model::LampPostModel{T}, us, N) where {T}
+    u = @SVector [T(0.0), model.h, model.θ, model.ϕ]
+    fill(u, n_samples)
+end
+
+function sample_even_direction(m::AbstractMetricParams{T}, ::LampPostModel{T}, us, N) where {T}
+    map(range(N)) do index
+        # uniform angle
+        i = index / N
+        ϕ = i * 2π
+        θ = acos(1 - 2i)
+        r, t, p = vector_to_local_sky(m, @view(us[i]), θ, ϕ)
+        @SVector [T(0.0), r, t, p]
+    end
+end

--- a/src/corona-models.jl
+++ b/src/corona-models.jl
@@ -6,18 +6,28 @@
     ϕ = 0.0
 end
 
-function sample_position(::AbstractMetricParams{T}, model::LampPostModel{T}, us, N) where {T}
+function sample_position(::AbstractMetricParams{T}, model::LampPostModel{T}, N) where {T}
     u = @SVector [T(0.0), model.h, model.θ, model.ϕ]
-    fill(u, n_samples)
+    fill(u, N)
 end
 
-function sample_even_direction(m::AbstractMetricParams{T}, ::LampPostModel{T}, us, N) where {T}
-    map(range(N)) do index
-        # uniform angle
-        i = index / N
-        ϕ = i * 2π
-        θ = acos(1 - 2i)
-        r, t, p = vector_to_local_sky(m, @view(us[i]), θ, ϕ)
+function sample_random_direction(m::AbstractMetricParams{T}, ::LampPostModel{T}, us, N) where {T}
+    map(1:N) do index
+        ϕ = rand(T) * 2π
+        θ = acos(1 - 2*rand(T))
+        r, t, p = vector_to_local_sky(m, us[index], θ, ϕ)
         @SVector [T(0.0), r, t, p]
     end
 end
+
+function sample_even_direction(m::AbstractMetricParams{T}, ::LampPostModel{T}, us, N) where {T}
+    map(1:N) do index
+        θ = acos(1 - 2 * (index / N))
+        # golden ratio
+        ϕ = π * (1 + √5) * index
+        r, t, p = vector_to_local_sky(m, us[index], θ, ϕ)
+        @SVector [T(0.0), r, t, p]
+    end
+end
+
+export LampPostModel

--- a/src/disc-profiles.jl
+++ b/src/disc-profiles.jl
@@ -1,0 +1,26 @@
+
+
+function __renderprofile(
+    m::AbstractMetricParams{T},
+    model::AbstractCoronaModel{T},
+    d::AbstractAccretionGeometry{T}
+    N, 
+    time_domain;
+    kwargs...
+) where {T}
+    # TODO
+    error("Not implemented for $(typeof(d)).")
+end
+
+
+function __renderprofile(
+    m::AbstractMetricParams{T},
+    model::AbstractCoronaModel{T},
+    d::GeometricThinDisc{T}
+    N, 
+    time_domain;
+    kwargs...
+) where {T}
+    # TODO
+    error("Not implemented for $(typeof(d)).")
+end

--- a/src/sky-geometry.jl
+++ b/src/sky-geometry.jl
@@ -1,0 +1,20 @@
+
+function convert_angles(r, theta, phi, obstheta, obsphi)
+    PHI = phi-obsphi
+    R = sqrt(r^2 + 1.0^2)
+    o1 = r * R * sin(theta) * sin(obstheta) * cos(PHI) + R^2 * cos(theta) * cos(obstheta)
+    o2 = R * cos(theta) * sin(obstheta) * cos(PHI) - r * sin(theta) * cos(obstheta)
+    o3 = sin(obstheta) * sin(PHI) / sin(theta)
+    sigma = r^2 + 1.0^2 * cos(theta)^2
+    -o1 / sigma, -o2 / sigma, o3 / R
+end
+
+
+
+function vector_to_local_sky(m::AbstractMetricParams{T}, u, θ, ϕ)
+    error("Not implemented for $(typeof(m))")
+end
+
+function vector_to_local_sky(m::BoyerLindquist{T}, u, θ, ϕ)
+    convert_angles(u[2], u[3], u[4], θ, ϕ)
+end

--- a/src/sky-geometry.jl
+++ b/src/sky-geometry.jl
@@ -1,20 +1,18 @@
 
-function convert_angles(r, theta, phi, obstheta, obsphi)
-    PHI = phi-obsphi
-    R = sqrt(r^2 + 1.0^2)
-    o1 = r * R * sin(theta) * sin(obstheta) * cos(PHI) + R^2 * cos(theta) * cos(obstheta)
-    o2 = R * cos(theta) * sin(obstheta) * cos(PHI) - r * sin(theta) * cos(obstheta)
-    o3 = sin(obstheta) * sin(PHI) / sin(theta)
-    sigma = r^2 + 1.0^2 * cos(theta)^2
+function convert_angles(a, r, θ, ϕ, θ_obs, ϕ_obs)
+    ϕ̃ = ϕ - ϕ_obs
+    R = sqrt(r^2 + a^2)
+    o1 = r * R * sin(θ) * sin(θ_obs) * cos(ϕ̃) + R^2 * cos(θ) * cos(θ_obs)
+    o2 = R * cos(θ) * sin(θ_obs) * cos(ϕ̃) - r * sin(θ) * cos(θ_obs)
+    o3 = sin(θ_obs) * sin(ϕ̃) / sin(θ)
+    sigma = r^2 + a^2 * cos(θ)^2
     -o1 / sigma, -o2 / sigma, o3 / R
 end
 
-
-
-function vector_to_local_sky(m::AbstractMetricParams{T}, u, θ, ϕ)
+function vector_to_local_sky(m::AbstractMetricParams{T}, u, θ, ϕ) where {T}
     error("Not implemented for $(typeof(m))")
 end
 
-function vector_to_local_sky(m::BoyerLindquist{T}, u, θ, ϕ)
-    convert_angles(u[2], u[3], u[4], θ, ϕ)
+function vector_to_local_sky(m::BoyerLindquist{T}, u, θ, ϕ) where {T}
+    convert_angles(m.a, u[2], u[3], u[4], θ, ϕ)
 end


### PR DESCRIPTION
## Added
- sampling pipeline for different corona models (currently only lamp post implemented)
- random and even direction sampler for sphere in Kerr metric (this needs to be made generic)
- method for saving geodesic paths for such a corona

## Todo
- direction sampler for arbitrary metrics
- Carter method methods
- a sense of what the disc "profile" is, beyond just a heatmap

This last point probably relies on the Ingram et al. 2019 paper, and their derivations for area propagation from source to the disc, and from the disc to the observer.

I will open other PRs to resolve these issues, so will downgrade the PR to v0.0.x until these are resolved, and refrain from adding to the registry.